### PR TITLE
Feature/headless rail carousel

### DIFF
--- a/carousel/src/components/FadeCarousel/index.tsx
+++ b/carousel/src/components/FadeCarousel/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import { CarouselProps } from "../../types";
 import "../globalStyle.css";
 import "./index.css";
-import { parsePercentage } from "../../utils";
+import { parsePercentage, handleThreshold } from "../../utils";
 import { defaultConfig } from "../../machines/config";
 import { CarouselItem } from "../CarouselItem";
 import { Dots } from "../Dot";
@@ -12,29 +12,6 @@ import classnames from "classnames";
 interface RailCarouselSettings extends CarouselProps {
   boundaryThreshold: number | string;
   transitionThreshold: number | string;
-}
-
-function handleThreshold(
-  input: number | string,
-  baseScale: number,
-  fallback: number,
-) {
-  switch (typeof input) {
-    case "string": {
-      try {
-        const percentage = parsePercentage(input);
-        return baseScale * percentage;
-      } catch (err) {
-        return fallback;
-      }
-    }
-    case "number": {
-      return input;
-    }
-    default:
-      console.log(`invalid threshold, using fallback: ${fallback}`);
-      return fallback;
-  }
 }
 
 export function FadeCarousel(props: CarouselProps) {

--- a/carousel/src/components/RailCarousel/Headless.tsx
+++ b/carousel/src/components/RailCarousel/Headless.tsx
@@ -1,0 +1,255 @@
+import React, { useRef, useState, useEffect } from "react";
+import classnames from "classnames";
+import { CarouselProps } from "../../types";
+import "../globalStyle.css";
+import "./index.css";
+import { defaultConfig } from "../../machines/config";
+import { handleThreshold } from "../../utils";
+import { useCarousel } from "../HeadlessCarousel/useCarousel";
+import { ChildrenProps } from "../HeadlessCarousel/types";
+
+interface RailCarouselSettings extends CarouselProps {
+  boundaryThreshold: number | string;
+  transitionThreshold: number | string;
+}
+
+export type HeadlessRailCarouselChildrenProps = RailCarouselSettings &
+  ChildrenProps & { itemWidth: number };
+
+export type HeadlessRailCarouselProps = CarouselProps & {
+  children: (args: HeadlessRailCarouselChildrenProps) => React.ReactNode;
+  preItems?: (args: HeadlessRailCarouselChildrenProps) => React.ReactNode;
+  postItems?: (args: HeadlessRailCarouselChildrenProps) => React.ReactNode;
+};
+
+export function HeadlessRailCarousel(props: HeadlessRailCarouselProps) {
+  const settings: RailCarouselSettings = {
+    ...defaultConfig,
+    boundaryThreshold: 50,
+    transitionThreshold: "50%",
+    ...props,
+  };
+  const {
+    totalItems,
+    slidesToShow,
+    transitionDelay,
+    responsive,
+    swipe,
+    boundaryThreshold: propsBoundaryThreshold,
+    transitionThreshold: propsTransitionThreshold,
+  } = settings;
+
+  const carousel = useCarousel(settings);
+  const { state, data, next, prev, grab, release } = carousel;
+
+  // Calculate each item's width based on slidesToShow
+  const [itemWidth, setItemWidth] = useState(1);
+  const listRef = useRef<HTMLDivElement>(null!);
+  const trackRef = useRef<HTMLDivElement>(null!);
+  const [boundaryThreshold, setBoundaryThreshold] = useState(50);
+  const [transitionThreshold, setTransitionThreshold] = useState(50);
+  const [move, setMove] = useState(0);
+  const start = useRef<number>(0);
+
+  function setStart(s: number) {
+    start.current = s;
+  }
+
+  function updateLayout() {
+    console.log("updating layout");
+    // TODO: margins, paddings and borders are not considered here
+    const w = listRef.current.clientWidth / slidesToShow;
+    setItemWidth(w);
+  }
+
+  function resetTouch() {
+    setMove(0);
+    setStart(0);
+  }
+
+  function isTouchEvent(e: any) {
+    return !!e.changedTouches;
+  }
+
+  function onTouchStart(e: any) {
+    e.preventDefault();
+
+    grab();
+
+    let diff = 0;
+    if (isTouchEvent(e)) {
+      diff = (e as TouchEvent).changedTouches[0].pageX;
+    } else {
+      diff = (e as MouseEvent).pageX;
+    }
+
+    setMove(0);
+    setStart(diff);
+  }
+
+  function onTouchMove(e: any) {
+    e.preventDefault();
+
+    if (!state.matches("grabbed")) {
+      return;
+    }
+
+    let diff = 0;
+    if (isTouchEvent(e)) {
+      diff = (e as TouchEvent).changedTouches[0].pageX;
+    } else {
+      diff = (e as MouseEvent).pageX;
+    }
+
+    const newMove = diff - start.current;
+
+    // Do not let more than 1 slide to be grabbed and moved
+    if (Math.abs(newMove) >= itemWidth) {
+      return;
+    }
+
+    // On the 1st item, grabbing by the size of boundaryThreshold to the right will circle back to the last item
+    if (
+      data.cursor === 1 &&
+      newMove > 0 &&
+      Math.abs(newMove) >= boundaryThreshold
+    ) {
+      release();
+      // TODO: this needs to be represented in Machine layer
+      data.dir === "ltr" && prev();
+      data.dir === "rtl" && next();
+      resetTouch();
+      return;
+    }
+
+    // On the last item, grabbing by the size of  boundaryThreshold to the left will circle back to the 1st item
+    if (
+      data.cursor === data.groups.length &&
+      newMove < 0 &&
+      Math.abs(newMove) >= boundaryThreshold
+    ) {
+      release();
+      data.dir === "ltr" && next();
+      data.dir === "rtl" && prev();
+      // next();
+      resetTouch();
+      return;
+    }
+
+    setMove(diff - start.current);
+  }
+
+  function onTouchEnd(e: any) {
+    e.preventDefault();
+
+    release();
+
+    let diff = 0;
+    if (isTouchEvent(e)) {
+      diff = (e as TouchEvent).changedTouches[0].pageX;
+    } else {
+      diff = (e as MouseEvent).pageX;
+    }
+
+    if (Math.abs(move) >= transitionThreshold) {
+      // grab to left
+      if (move < 0) {
+        data.dir === "ltr" && next();
+        data.dir === "rtl" && prev();
+      } else {
+        // grab to right
+        data.dir === "ltr" && prev();
+        data.dir === "rtl" && next();
+      }
+      resetTouch();
+    }
+
+    setMove(0);
+    setStart(diff);
+  }
+
+  // Sync boundaryThreshold and transitionThreshold with itemWidth
+  useEffect(() => {
+    setBoundaryThreshold(
+      handleThreshold(propsBoundaryThreshold, itemWidth, 50),
+    );
+    setTransitionThreshold(
+      handleThreshold(propsTransitionThreshold, itemWidth, 50),
+    );
+  }, [itemWidth]);
+
+  // Resize listener
+  useEffect(() => {
+    updateLayout();
+
+    if (responsive) {
+      window.addEventListener("resize", updateLayout);
+    }
+
+    return () => {
+      console.debug("removing resize listener");
+      window.removeEventListener("resize", updateLayout);
+    };
+  }, []);
+
+  const totalWidth = totalItems * itemWidth;
+
+  const swipeEventListeners = {
+    onMouseDown: onTouchStart,
+    onTouchStart: onTouchStart,
+    onMouseUp: onTouchEnd,
+    onTouchEnd: onTouchEnd,
+    onMouseMove: onTouchMove,
+    onTouchMove: onTouchMove,
+  };
+
+  const rendererArguments: HeadlessRailCarouselChildrenProps = {
+    ...settings,
+    ...carousel,
+    itemWidth,
+  };
+
+  // TODO: explore the possibility of exposing HeadlessRailCarousel.Track component instead
+  return (
+    <div
+      className="carousel rail-carousel"
+      style={
+        {
+          "--transition-delay": `${transitionDelay}ms`,
+        } as React.CSSProperties
+      }
+    >
+      {/* Render preItems */}
+      {typeof props.preItems === "function" &&
+        props.preItems({
+          ...settings,
+          ...carousel,
+          itemWidth,
+        })}
+      {/* Render list of items in carousel */}
+      <div className="items-list" ref={listRef}>
+        <div
+          ref={trackRef}
+          className={classnames("items-track", {
+            animated: !state.matches("grabbed"),
+          })}
+          style={{
+            width: totalWidth,
+            transform: `translate3d(${(data.cursor - 1) * -1 * itemWidth +
+              move}px, 0, 0)`,
+          }}
+          {...(swipe && swipeEventListeners)}
+        >
+          {props.children(rendererArguments)}
+        </div>
+      </div>
+      {/* Render postItems */}
+      {typeof props.postItems === "function" &&
+        props.postItems({
+          ...settings,
+          ...carousel,
+          itemWidth,
+        })}
+    </div>
+  );
+}

--- a/carousel/src/components/RailCarousel/index.tsx
+++ b/carousel/src/components/RailCarousel/index.tsx
@@ -4,7 +4,7 @@ import { CarouselProps } from "../../types";
 import "../globalStyle.css";
 import "./index.css";
 import { defaultConfig } from "../../machines/config";
-import { parsePercentage } from "../../utils";
+import { handleThreshold } from "../../utils";
 import { CarouselItem } from "../CarouselItem";
 import { Dots } from "../Dot";
 import { useCarousel } from "../HeadlessCarousel/useCarousel";
@@ -12,29 +12,6 @@ import { useCarousel } from "../HeadlessCarousel/useCarousel";
 interface RailCarouselSettings extends CarouselProps {
   boundaryThreshold: number | string;
   transitionThreshold: number | string;
-}
-
-function handleThreshold(
-  input: number | string,
-  baseScale: number,
-  fallback: number,
-) {
-  switch (typeof input) {
-    case "string": {
-      try {
-        const percentage = parsePercentage(input);
-        return baseScale * percentage;
-      } catch (err) {
-        return fallback;
-      }
-    }
-    case "number": {
-      return input;
-    }
-    default:
-      console.log(`invalid threshold, using fallback: ${fallback}`);
-      return fallback;
-  }
 }
 
 export function RailCarousel(props: CarouselProps) {

--- a/carousel/src/components/RailCarousel/index.tsx
+++ b/carousel/src/components/RailCarousel/index.tsx
@@ -1,333 +1,127 @@
-import React, { useRef, useState, useEffect } from "react";
+import React from "react";
 import classnames from "classnames";
 import { CarouselProps } from "../../types";
 import "../globalStyle.css";
 import "./index.css";
-import { defaultConfig } from "../../machines/config";
-import { handleThreshold } from "../../utils";
 import { CarouselItem } from "../CarouselItem";
 import { Dots } from "../Dot";
-import { useCarousel } from "../HeadlessCarousel/useCarousel";
-
-interface RailCarouselSettings extends CarouselProps {
-  boundaryThreshold: number | string;
-  transitionThreshold: number | string;
-}
+import { HeadlessRailCarousel } from "./Headless";
 
 export function RailCarousel(props: CarouselProps) {
-  const settings: RailCarouselSettings = {
-    ...defaultConfig,
-    boundaryThreshold: 50,
-    transitionThreshold: "50%",
-    ...props,
-  };
-  const {
-    items,
-    totalItems,
-    slidesToShow,
-    transitionDelay,
-    responsive,
-    swipe,
-    boundaryThreshold: propsBoundaryThreshold,
-    transitionThreshold: propsTransitionThreshold,
-  } = settings;
-
-  const {
-    state,
-    data,
-    next,
-    prev,
-    goTo,
-    play,
-    pause,
-    grab,
-    release,
-    turnOn,
-    turnOff,
-  } = useCarousel(settings);
-
-  // Calculate each item's width based on slidesToShow
-  const [itemWidth, setItemWidth] = useState(1);
-  const listRef = useRef<HTMLDivElement>(null!);
-  const trackRef = useRef<HTMLDivElement>(null!);
-  const [boundaryThreshold, setBoundaryThreshold] = useState(50);
-  const [transitionThreshold, setTransitionThreshold] = useState(50);
-  const [move, setMove] = useState(0);
-  const start = useRef<number>(0);
-
-  function setStart(s: number) {
-    start.current = s;
-  }
-
-  function updateLayout() {
-    console.log("updating layout");
-    // TODO: margins, paddings and borders are not considered here
-    const w = listRef.current.clientWidth / slidesToShow;
-    setItemWidth(w);
-  }
-
-  function resetTouch() {
-    setMove(0);
-    setStart(0);
-  }
-
-  function isTouchEvent(e: any) {
-    return !!e.changedTouches;
-  }
-
-  function onTouchStart(e: any) {
-    e.preventDefault();
-
-    grab();
-
-    let diff = 0;
-    if (isTouchEvent(e)) {
-      diff = (e as TouchEvent).changedTouches[0].pageX;
-    } else {
-      diff = (e as MouseEvent).pageX;
-    }
-
-    setMove(0);
-    setStart(diff);
-  }
-
-  function onTouchMove(e: any) {
-    e.preventDefault();
-
-    if (!state.matches("grabbed")) {
-      return;
-    }
-
-    let diff = 0;
-    if (isTouchEvent(e)) {
-      diff = (e as TouchEvent).changedTouches[0].pageX;
-    } else {
-      diff = (e as MouseEvent).pageX;
-    }
-
-    const newMove = diff - start.current;
-
-    // Do not let more than 1 slide to be grabbed and moved
-    if (Math.abs(newMove) >= itemWidth) {
-      return;
-    }
-
-    // On the 1st item, grabbing by the size of boundaryThreshold to the right will circle back to the last item
-    if (
-      data.cursor === 1 &&
-      newMove > 0 &&
-      Math.abs(newMove) >= boundaryThreshold
-    ) {
-      release();
-      // TODO: this needs to be represented in Machine layer
-      data.dir === "ltr" && prev();
-      data.dir === "rtl" && next();
-      // prev();
-      resetTouch();
-      return;
-    }
-
-    // On the last item, grabbing by the size of  boundaryThreshold to the left will circle back to the 1st item
-    if (
-      data.cursor === data.groups.length &&
-      newMove < 0 &&
-      Math.abs(newMove) >= boundaryThreshold
-    ) {
-      release();
-      data.dir === "ltr" && next();
-      data.dir === "rtl" && prev();
-      // next();
-      resetTouch();
-      return;
-    }
-
-    setMove(diff - start.current);
-  }
-
-  function onTouchEnd(e: any) {
-    e.preventDefault();
-
-    release();
-
-    let diff = 0;
-    if (isTouchEvent(e)) {
-      diff = (e as TouchEvent).changedTouches[0].pageX;
-    } else {
-      diff = (e as MouseEvent).pageX;
-    }
-
-    if (Math.abs(move) >= transitionThreshold) {
-      // grab to left
-      if (move < 0) {
-        data.dir === "ltr" && next();
-        data.dir === "rtl" && prev();
-        // next();
-      } else {
-        // grab to right
-        data.dir === "ltr" && prev();
-        data.dir === "rtl" && next();
-        // prev();
-      }
-      resetTouch();
-    }
-
-    setMove(0);
-    setStart(diff);
-    // setGrabbing(false);
-  }
-
-  // Sync boundaryThreshold and transitionThreshold with itemWidth
-  useEffect(() => {
-    setBoundaryThreshold(
-      handleThreshold(propsBoundaryThreshold, itemWidth, 50),
-    );
-    setTransitionThreshold(
-      handleThreshold(propsTransitionThreshold, itemWidth, 50),
-    );
-  }, [itemWidth]);
-
-  // Resize listener
-  useEffect(() => {
-    updateLayout();
-
-    if (responsive) {
-      window.addEventListener("resize", updateLayout);
-    }
-
-    return () => {
-      console.debug("removing resize listener");
-      window.removeEventListener("resize", updateLayout);
-    };
-  }, []);
-
-  const totalWidth = totalItems * itemWidth;
-
-  const swipeEventListeners = {
-    onMouseDown: onTouchStart,
-    onTouchStart: onTouchStart,
-    onMouseUp: onTouchEnd,
-    onTouchEnd: onTouchEnd,
-    onMouseMove: onTouchMove,
-    onTouchMove: onTouchMove,
-  };
-
   return (
-    <div
-      className="carousel rail-carousel"
-      style={
-        {
-          "--transition-delay": `${transitionDelay}ms`,
-        } as React.CSSProperties
-      }
+    <HeadlessRailCarousel
+      items={props.items}
+      totalItems={props.totalItems}
+      slidesToShow={props.slidesToShow}
+      startIndex={props.startIndex}
+      dir={props.dir}
+      infinite={props.infinite}
+      swipe={props.swipe}
+      preItems={nProps => (
+        <>
+          <pre>{JSON.stringify(nProps.state.value)}</pre>
+          <pre>cursor: {nProps.data.cursor}</pre>
+        </>
+      )}
+      postItems={nProps => (
+        <>
+          <button
+            className="next"
+            onClick={() => {
+              nProps.next();
+            }}
+          />
+          <button
+            className="prev"
+            onClick={() => {
+              nProps.prev();
+            }}
+          />
+          {
+            <button
+              onClick={() => {
+                nProps.pause();
+              }}
+            >
+              PAUSE
+            </button>
+          }
+          {
+            <button
+              onClick={() => {
+                nProps.play();
+              }}
+            >
+              PLAY
+            </button>
+          }
+          {
+            <button
+              onClick={() => {
+                nProps.turnOn();
+              }}
+            >
+              TURN ON
+            </button>
+          }
+          {
+            <button
+              onClick={() => {
+                nProps.turnOff();
+              }}
+            >
+              TURN OFF
+            </button>
+          }
+          {
+            <button
+              onClick={() => {
+                nProps.grab();
+              }}
+            >
+              GRAB
+            </button>
+          }
+          {
+            <button
+              onClick={() => {
+                nProps.release();
+              }}
+            >
+              RELEASE
+            </button>
+          }
+          <Dots
+            dots={nProps.data.groups}
+            onDotClick={nProps.goTo}
+            activeIndex={nProps.data.cursor - 1}
+          />
+        </>
+      )}
     >
-      <pre>{JSON.stringify(state.value)}</pre>
-      <pre>cursor: {data.cursor}</pre>
-      <div className="items-list" ref={listRef}>
-        <div
-          ref={trackRef}
-          className={classnames("items-track", {
-            animated: !state.matches("grabbed"),
-          })}
-          style={{
-            width: totalWidth,
-            transform: `translate3d(${(data.cursor - 1) * -1 * itemWidth +
-              move}px, 0, 0)`,
-          }}
-        >
-          {items.map((item, itemIdx) => {
+      {hProps => (
+        <>
+          {hProps.items.map((item, itemIdx) => {
             return (
               <div className="items-group" key={itemIdx}>
                 <div
                   className={classnames("item", {
-                    grabbable: swipe,
-                    grabbing: state.matches("grabbed"),
+                    grabbable: hProps.swipe,
+                    grabbing: hProps.state.matches("grabbed"),
                   })}
                   style={{
-                    width: itemWidth,
+                    width: hProps.itemWidth,
                     overflow: "hidden",
                   }}
                   key={item.key || itemIdx}
-                  // Only attach swipe handlers when `swipe` config is set to true
-                  {...(swipe && swipeEventListeners)}
                 >
                   <CarouselItem item={item} />
                 </div>
               </div>
             );
           })}
-        </div>
-      </div>
-      <button
-        className="next"
-        onClick={() => {
-          next();
-        }}
-      />
-      <button
-        className="prev"
-        onClick={() => {
-          prev();
-        }}
-      />
-      {
-        <button
-          onClick={() => {
-            pause();
-          }}
-        >
-          PAUSE
-        </button>
-      }
-      {
-        <button
-          onClick={() => {
-            play();
-          }}
-        >
-          PLAY
-        </button>
-      }
-      {
-        <button
-          onClick={() => {
-            turnOn();
-          }}
-        >
-          TURN ON
-        </button>
-      }
-      {
-        <button
-          onClick={() => {
-            turnOff();
-          }}
-        >
-          TURN OFF
-        </button>
-      }
-      {
-        <button
-          onClick={() => {
-            grab();
-          }}
-        >
-          GRAB
-        </button>
-      }
-      {
-        <button
-          onClick={() => {
-            release();
-          }}
-        >
-          RELEASE
-        </button>
-      }
-      <Dots
-        dots={data.groups}
-        onDotClick={goTo}
-        activeIndex={data.cursor - 1}
-      />
-    </div>
+        </>
+      )}
+    </HeadlessRailCarousel>
   );
 }

--- a/carousel/src/utils.ts
+++ b/carousel/src/utils.ts
@@ -153,3 +153,26 @@ export function parsePercentage(perc: string) {
   }
   return parsed / 100;
 }
+
+export function handleThreshold(
+  input: number | string,
+  baseScale: number,
+  fallback: number,
+) {
+  switch (typeof input) {
+    case "string": {
+      try {
+        const percentage = parsePercentage(input);
+        return baseScale * percentage;
+      } catch (err) {
+        return fallback;
+      }
+    }
+    case "number": {
+      return input;
+    }
+    default:
+      console.log(`invalid threshold, using fallback: ${fallback}`);
+      return fallback;
+  }
+}


### PR DESCRIPTION
closes: https://github.com/farskid/statecharts-components/issues/9

This PR:

- Adds `HeadlessRailCarousel` component which abstracts swiping logic and rail effect mechanics to be able to build custom rail carousels such as Instagram and Google photos ones.
- Changes `RailCarousel` oto internally use the headless version.